### PR TITLE
feat: add sip plugin functions

### DIFF
--- a/src/main/java/io/github/kinsleykajiva/janus/JanusUtils.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/JanusUtils.java
@@ -2,6 +2,28 @@ package io.github.kinsleykajiva.janus;
 
 public class JanusUtils {
 	
+	public enum SipHoldDirection {
+		// Indicates the SIP endpoint will only send media (RFC 3264, SDP "a=sendonly")
+		// See Janus docs: https://janus.conf.meetecho.com/docs.html#siphold
+		SENDONLY("sendonly"),
+		// Indicates the SIP endpoint will only receive media (RFC 3264, SDP "a=recvonly")
+		// See Janus docs: https://janus.conf.meetecho.com/docs.html#siphold
+		RECVONLY("recvonly"),
+		// Indicates the SIP endpoint will neither send nor receive media (RFC 3264, SDP "a=inactive")
+		// See Janus docs: https://janus.conf.meetecho.com/docs.html#siphold
+		INACTIVE("inactive");
+	
+		private final String value;
+	
+		SipHoldDirection(String value) {
+			this.value = value;
+		}
+	
+		public String getValue() {
+			return value;
+		}
+	}
+	
 	/**
 	 * Validates whether the given address is a valid IP address or domain name.
 	 * Removes any leading "http://" or "https://" before validation.

--- a/src/main/java/io/github/kinsleykajiva/janus/handle/impl/SipHandle.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/handle/impl/SipHandle.java
@@ -1,11 +1,13 @@
 package io.github.kinsleykajiva.janus.handle.impl;
 
 import io.github.kinsleykajiva.janus.JanusSession;
+import io.github.kinsleykajiva.janus.JanusUtils;
 import io.github.kinsleykajiva.janus.event.*;
 import io.github.kinsleykajiva.janus.handle.HandleType;
 import io.github.kinsleykajiva.janus.handle.JanusHandle;
 import org.json.JSONObject;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -280,7 +282,7 @@ public class SipHandle extends JanusHandle {
 	 * @param headers Custom headers to add to the SIP OK.
 	 * @return A {@link CompletableFuture} that resolves with the server's response.
 	 */
-	public CompletableFuture<JSONObject> accept(final JSONObject jsep, final String srtp, final JSONObject headers) {
+	public CompletableFuture<JSONObject> acceptInComingCall(final JSONObject jsep, @Nullable final String srtp,@Nullable final JSONObject headers) {
 		final var body = new JSONObject().put("request", "accept");
 		if (srtp != null && !srtp.isEmpty()) {
 			body.put("srtp", srtp);
@@ -297,11 +299,11 @@ public class SipHandle extends JanusHandle {
 	 * @param direction The media direction (e.g., "sendonly", "recvonly", "inactive").
 	 * @return A {@link CompletableFuture} that resolves with the server's response.
 	 */
-	public CompletableFuture<JSONObject> hold(final String direction) {
+	public CompletableFuture<JSONObject> hold(final JanusUtils.@NonNull SipHoldDirection direction) {
 		final var body = new JSONObject().put("request", "hold");
-		if (direction != null && !direction.isEmpty()) {
+		
 			body.put("direction", direction);
-		}
+		
 		return sendMessage(body);
 	}
 
@@ -372,7 +374,9 @@ public class SipHandle extends JanusHandle {
 	 * @return A {@link CompletableFuture} that resolves with the server's response.
 	 */
 	public CompletableFuture<JSONObject> message(final String content, final String contentType, final String uri, final JSONObject headers) {
-		final var body = new JSONObject().put("request", "message").put("content", content);
+		final var body = new JSONObject()
+				                 .put("request", "message")
+				                 .put("content", content);
 		if (contentType != null && !contentType.isEmpty()) {
 			body.put("content_type", contentType);
 		}


### PR DESCRIPTION
Adds the following functions to the SIP plugin:
- unregister
- progress
- accept
- decline
- info
- message
- dtmf
- subscribe
- unsubscribe
- transfer
- recording
- keyframe
- hold
- unhold
- update

All functions are documented with Javadoc comments and follow the existing coding style.