### PR TITLE
feat: Update README and add Maven deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,90 @@
+# Janus Server Java SDK
+
+![version](https://img.shields.io/badge/version-0.10.0-blue)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+A Java SDK for interacting with the Janus WebRTC Server. This SDK is designed for Java applications (Desktop & Web-Backend) and provides a high-level API to communicate with the Janus server.
+
+## Features
+
+*   **Session and Handle Management:** Easily create and manage Janus sessions and handles.
+*   **Plugin Support:**
+    *   **Video Room:** Functionality for creating, joining, and managing video rooms.
+    *   **Audio Bridge:** Functionality for creating, joining, and managing audio bridges.
+    *   **SIP Gateway:** Basic support for interacting with the SIP plugin.
+*   **Asynchronous API:** Built with asynchronous communication in mind.
+*   **Extensible:** Designed to be easily extended to support other Janus plugins.
+
+## Requirements
+
+*   **Minimum JDK:** Java 21 or higher.
+*   **Janus Server:** A running instance of the Janus WebRTC Server.
+
+## Installation
+
+To use this SDK in your Maven project, add the following dependency to your `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>io.github.kinsleykajiva</groupId>
+    <artifactId>janus-server-java-sdk</artifactId>
+    <version>0.10.0</version>
+</dependency>
+```
+
+## Getting Started
+
+Here's a quick example of how to create a Janus session and a handle:
+
+```java
+import io.github.kinsleykajiva.JanusServer;
+import io.github.kinsleykajiva.JanusSession;
+import io.github.kinsleykajiva.JanusHandle;
+import io.github.kinsleykajiva.interfaces.JanusRTCInterface;
+
+public class Main {
+    public static void main(String[] args) {
+        // Implement the JanusRTCInterface to handle events
+        JanusRTCInterface rtcInterface = new JanusRTCInterface() {
+            @Override
+            public void onSessionCreated(JanusSession session) {
+                System.out.println("Session created: " + session.getSessionId());
+            }
+
+            @Override
+            public void onHandleAttached(JanusHandle handle) {
+                System.out.println("Handle attached: " + handle.getHandleId());
+            }
+
+            // Implement other methods...
+        };
+
+        // Create a JanusServer instance
+        JanusServer janusServer = new JanusServer("ws://your-janus-server:8188", rtcInterface);
+
+        // Connect to the server
+        janusServer.connect();
+
+        // Create a session
+        janusServer.createSession();
+
+        // ... and so on.
+    }
+}
+```
+
+## Documentation
+
+For more detailed information and examples, please refer to the documentation in the `docs` directory:
+
+*   [Video Room Example](./docs/videoRoomExamples.md)
+*   [Audio Bridge Example](./docs/AudioBridgeExample.md)
+*   [SIP Example](./docs/SipExample.md)
+
+## Contributing
+
+Contributions are welcome! Please read our [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to this project.
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,3 +1,0 @@
-# Janus WebRTC Server SDK for Java (Desktop & Web-Backend)
-
-![version](https://img.shields.io/badge/version-0.10.0-blue)

--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,24 @@
     <groupId>io.github.kinsleykajiva</groupId>
     <artifactId>janus-server-java-sdk</artifactId>
     <version>0.10.0</version>
+    <name>janus-server-java-sdk</name>
     <description>Java Janus WebRTC sever SDK</description>
+    <url>https://github.com/kinsleykajiva/janus-server-java-sdk</url>
     <packaging>jar</packaging>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
     <scm>
-        <connection>scm:git@github.com:kinsleykajiva/janus-server-java-sdk.git</connection>
+        <connection>scm:git:git@github.com:kinsleykajiva/janus-server-java-sdk.git</connection>
         <developerConnection>scm:git@github.com:kinsleykajiva/janus-server-java-sdk.git</developerConnection>
         <url>https://github.com/kinsleykajiva/janus-server-java-sdk.git</url>
     </scm>
@@ -56,5 +69,54 @@
             <version>1.0.0</version>
         </dependency>
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
This commit introduces two main improvements:

1.  **Comprehensive README:** The `README.md` file has been completely rewritten to provide a professional and detailed overview of the project. It now includes:
    *   A clear project description and features.
    *   Minimum JDK requirement.
    *   Maven installation instructions.
    *   A "Getting Started" code example.
    *   Links to detailed documentation, contributing guidelines, and the license.
    *   The file has also been renamed from `ReadMe.md` to `README.md` to follow standard conventions.

2.  **Maven Deployment Configuration:** The `pom.xml` has been updated to include the necessary configuration for deploying the library to Maven Central. This includes:
    *   Adding project metadata (`name`, `url`).
    *   Configuring `distributionManagement` for snapshot and release repositories.
    *   Adding the `maven-source-plugin`, `maven-javadoc-plugin`, and `maven-gpg-plugin` to generate the required artifacts and sign the release.