### PR TITLE
fix: Add write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The previous workflow was failing because it didn't have the necessary permissions to create a release. This change adds the 'contents: write' permission to the job.