### PR TITLE
feat: Add Janus Admin API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ For more detailed information and examples, please refer to the documentation in
 *   [Video Room Example](./docs/videoRoomExamples.md)
 *   [Audio Bridge Example](./docs/AudioBridgeExample.md)
 *   [SIP Example](./docs/SipExample.md)
+*   [Admin API Client](./docs/JanusAdmin.md)
 
 ## Contributing
 

--- a/docs/JanusAdmin.md
+++ b/docs/JanusAdmin.md
@@ -1,0 +1,176 @@
+# Janus Admin API Client (`JanusAdminClient`)
+
+The `JanusAdminClient` provides a high-level interface for interacting with the Janus Admin API. This client allows you to perform administrative and monitoring tasks on your Janus instance programmatically. It uses a WebSocket connection for real-time communication and provides methods for sending various admin commands.
+
+## Features
+
+-   Connects to the Janus Admin WebSocket using the `janus-admin-protocol`.
+-   Handles authentication using the `admin_secret`.
+-   Provides asynchronous methods for sending admin commands, returning `CompletableFuture` objects.
+-   Includes a `JanusAdminMonitor` for listening to asynchronous events from the Janus server.
+-   Supports a variety of admin commands, including:
+    -   `ping`: For health checks.
+    -   `info`: To get server information.
+    -   `list_sessions`: To list all active sessions.
+    -   `list_handles`: To list all handles for a session.
+    -   `destroy_session`: To terminate a session.
+    -   `message_plugin`: To send messages to a specific plugin handle.
+    -   `get_status`: To get the current status of runtime-modifiable settings.
+    -   `set_log_level`: To change the log level on the fly.
+
+## Getting Started
+
+### Configuration
+
+First, you need to create a `JanusAdminConfiguration` object. This object holds the URI of the Janus Admin WebSocket and the `admin_secret` required for authentication.
+
+```java
+import io.github.kinsleykajiva.janus.admin.JanusAdminConfiguration;
+import java.net.URI;
+
+// The admin websocket is typically on a different port than the regular Janus API.
+// Check your Janus configuration (janus.transport.websockets.jcfg).
+URI adminUri = URI.create("ws://localhost:7188/janus");
+String adminSecret = "janusoverlord"; // Replace with your admin secret
+
+JanusAdminConfiguration adminConfig = new JanusAdminConfiguration(adminUri, adminSecret);
+```
+
+### Creating a Client
+
+Once you have the configuration, you can create a `JanusAdminClient` instance. The client will automatically connect to the Janus Admin WebSocket upon creation.
+
+```java
+import io.github.kinsleykajiva.janus.admin.JanusAdminClient;
+
+JanusAdminClient adminClient = new JanusAdminClient(adminConfig);
+```
+
+### Disconnecting the Client
+
+When you are finished with the client, it's important to disconnect it to release resources properly.
+
+```java
+adminClient.disconnect();
+```
+
+## Usage Examples
+
+Here are examples of how to use the various methods of the `JanusAdminClient`. All methods are asynchronous and return a `CompletableFuture`.
+
+### Ping
+
+The `ping` method is useful for checking if the Janus Admin API is responsive.
+
+```java
+// Send a ping request and wait for the response
+adminClient.ping().thenAccept(response -> {
+    // The response is a JSON object: {"janus": "pong", "transaction": "..."}
+    System.out.println("Ping response: " + response.toString(2));
+}).get(); // .get() is used here for simplicity, but in a real application, you should handle the future asynchronously.
+```
+
+### Get Server Info
+
+The `info` method retrieves detailed information about the Janus instance.
+
+```java
+adminClient.info().thenAccept(serverInfo -> {
+    System.out.println("Janus Version: " + serverInfo.versionString());
+    System.out.println("Plugins: " + serverInfo.plugins().keySet());
+}).get();
+```
+
+### Get Status
+
+The `getStatus` method retrieves the current values of runtime-modifiable settings.
+
+```java
+adminClient.getStatus().thenAccept(status -> {
+    // The response contains information about log levels, session timeouts, etc.
+    System.out.println("Current Status: " + status.toString(2));
+}).get();
+```
+
+### List Sessions
+
+The `listSessions` method returns a list of all active session IDs.
+
+```java
+adminClient.listSessions().thenAccept(sessionsResponse -> {
+    System.out.println("Active sessions: " + sessionsResponse.getSessionIds());
+}).get();
+```
+
+### List Handles
+
+The `listHandles` method returns a list of all active handle IDs for a given session.
+
+```java
+long sessionId = 123456789; // Replace with a real session ID from listSessions()
+adminClient.listHandles(sessionId).thenAccept(handlesResponse -> {
+    System.out.println("Handles for session " + sessionId + ": " + handlesResponse.getHandleIds());
+}).get();
+```
+
+### Destroy Session
+
+The `destroySession` method terminates a specific session.
+
+```java
+long sessionIdToDestroy = 123456789; // Replace with a real session ID
+adminClient.destroySession(sessionIdToDestroy).thenAccept(response -> {
+    // The response is a generic success message.
+    System.out.println("Destroy session response: " + response.toString(2));
+}).get();
+```
+
+### Set Log Level
+
+The `setLogLevel` method allows you to change the Janus log level on the fly.
+
+```java
+// Set the log level to 4 (debug)
+adminClient.setLogLevel(4).thenAccept(response -> {
+    System.out.println("Set log level response: " + response.toString(2));
+}).get();
+```
+
+### Message Plugin
+
+The `messagePlugin` method is a powerful tool that allows you to send a custom message to a specific plugin handle. The body of the message is a `JSONObject` that you construct.
+
+```java
+long sessionId = 123456789; // A valid session ID
+long handleId = 987654321;  // A valid handle ID for a plugin that supports admin messages
+
+// Example: Send a 'list' request to the VideoRoom plugin
+JSONObject videoRoomListRequest = new JSONObject();
+videoRoomListRequest.put("request", "list");
+
+adminClient.messagePlugin(sessionId, handleId, videoRoomListRequest).thenAccept(response -> {
+    // The response will be the plugin-specific response to the 'list' request.
+    System.out.println("VideoRoom list response: " + response.toString(2));
+}).get();
+```
+
+## Event Monitoring
+
+The `JanusAdminClient` includes a `JanusAdminMonitor` that allows you to listen for asynchronous events from the Janus server.
+
+```java
+adminClient.getAdminMonitor().addListener(event -> {
+    // This listener will be called for any event that is not a direct response to a transaction.
+    // Events can include session creation/destruction, handle attachment/detachment, media events, etc.
+    System.out.println(">>> ADMIN EVENT: " + event.toString(2));
+});
+```
+
+## Performance Considerations and Hints
+
+-   **Asynchronous Operations:** All methods in `JanusAdminClient` are asynchronous and return a `CompletableFuture`. In a real-world application, you should avoid using `.get()` as it blocks the current thread. Instead, use chained calls (`thenApply`, `thenAccept`, `thenCompose`) or other asynchronous patterns to handle the results.
+-   **Resource Management:** Always call `disconnect()` on the `JanusAdminClient` when you are finished with it. This ensures that the WebSocket connection and the underlying thread pools are properly shut down.
+-   **Admin Secret:** The `admin_secret` is a sensitive piece of information. Ensure that it is stored and managed securely.
+-   **Event Handling:** The `onEvent` method of your `JanusAdminEventListener` should be lightweight and non-blocking. If you need to perform long-running operations in response to an event, dispatch them to a separate thread pool to avoid blocking the event processing thread.
+-   **Error Handling:** When working with `CompletableFuture`, always consider adding error handling using `.exceptionally()` or `.handle()` to deal with potential exceptions, such as connection failures or timeouts.
+-   **`message_plugin` Flexibility:** The `message_plugin` command is very powerful but also requires you to know the specific message format expected by the plugin you are targeting. Always refer to the documentation of the specific Janus plugin for details on the admin messages it supports.

--- a/src/main/java/io/github/kinsleykajiva/Main.java
+++ b/src/main/java/io/github/kinsleykajiva/Main.java
@@ -205,20 +205,46 @@ public class Main {
             System.out.println(">>> ADMIN EVENT: " + event.toString(2));
         });
 
+        System.out.println("Pinging admin endpoint...");
+        adminClient.ping().thenAccept(response -> {
+            System.out.println("Ping response: " + response.toString(2));
+        }).get();
+
+        System.out.println("Getting server info...");
+        adminClient.info().thenAccept(info -> {
+            System.out.println("Server info: " + info.versionString());
+        }).get();
+
+        System.out.println("Getting status...");
+        adminClient.getStatus().thenAccept(status -> {
+            System.out.println("Status: " + status.toString(2));
+        }).get();
+
         System.out.println("Listing active sessions...");
         ListSessionsResponse sessionsResponse = adminClient.listSessions().get();
         System.out.println("Active sessions: " + sessionsResponse.getSessionIds());
 
         if (!sessionsResponse.getSessionIds().isEmpty()) {
             long firstSessionId = sessionsResponse.getSessionIds().get(0);
-            System.out.println("Getting handles for session: " + firstSessionId);
-            // This is a conceptual call. To get handles, you would need a 'list_handles' request.
-            // We will assume a handle ID for the handle_info call.
-            long handleId = 123456789; // Replace with a real handle ID
-            // adminClient.handleInfo(firstSessionId, handleId).thenAccept(handleInfo -> {
-            //     System.out.println("Handle info: " + handleInfo.getInfo().toString(2));
-            // });
+            System.out.println("Listing handles for session: " + firstSessionId);
+            adminClient.listHandles(firstSessionId).thenAccept(handles -> {
+                System.out.println("Handles: " + handles.getHandleIds());
+            }).get();
         }
+
+        System.out.println("Setting log level to 4...");
+        adminClient.setLogLevel(4).get();
+        System.out.println("Log level set.");
+
+        System.out.println("Getting status again...");
+        adminClient.getStatus().thenAccept(status -> {
+            System.out.println("Status: " + status.toString(2));
+        }).get();
+
+        System.out.println("Setting log level back to 3...");
+        adminClient.setLogLevel(3).get();
+        System.out.println("Log level set.");
+
 
         adminClient.disconnect();
         System.out.println("\n--- Admin Client Example Finished ---\n");

--- a/src/main/java/io/github/kinsleykajiva/Main.java
+++ b/src/main/java/io/github/kinsleykajiva/Main.java
@@ -4,6 +4,9 @@ import io.github.kinsleykajiva.janus.JanusClient;
 import io.github.kinsleykajiva.janus.JanusConfiguration;
 import io.github.kinsleykajiva.janus.JanusSession;
 import io.github.kinsleykajiva.janus.ServerInfo;
+import io.github.kinsleykajiva.janus.admin.JanusAdminClient;
+import io.github.kinsleykajiva.janus.admin.JanusAdminConfiguration;
+import io.github.kinsleykajiva.janus.admin.messages.ListSessionsResponse;
 import io.github.kinsleykajiva.janus.handle.impl.VideoRoomHandle;
 import io.github.kinsleykajiva.janus.plugins.videoroom.events.*;
 import io.github.kinsleykajiva.janus.plugins.videoroom.listeners.JanusVideoRoomListener;
@@ -11,6 +14,7 @@ import io.github.kinsleykajiva.janus.plugins.videoroom.models.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 public class Main {
@@ -27,6 +31,11 @@ public class Main {
             "/janus",
             false,
             true
+        );
+
+        JanusAdminConfiguration adminConfig = new JanusAdminConfiguration(
+            URI.create("ws://localhost:7188/janus"),
+            "janusoverlord"
         );
 
         JanusClient client = new JanusClient(config);
@@ -52,7 +61,10 @@ public class Main {
             logger.info("Session created with ID: {}", session.getSessionId());
 
             // Run the VideoRoom example
-            runVideoRoomExample(session);
+            // runVideoRoomExample(session);
+
+            // Run the Admin Client Example
+            runAdminClientExample(adminConfig);
 
 
             // Keep the application running to listen for more events
@@ -182,5 +194,33 @@ public class Main {
         videoRoomHandle.destroyRoom(destroyRequest).get(); // An `onRoomDestroyed` event will fire for the handle
 
         System.out.println("\n--- VideoRoom Example Finished ---\n");
+    }
+
+    public static void runAdminClientExample(JanusAdminConfiguration adminConfig) throws Exception {
+        System.out.println("\n--- Running Admin Client Example ---\n");
+
+        JanusAdminClient adminClient = new JanusAdminClient(adminConfig);
+
+        adminClient.getAdminMonitor().addListener(event -> {
+            System.out.println(">>> ADMIN EVENT: " + event.toString(2));
+        });
+
+        System.out.println("Listing active sessions...");
+        ListSessionsResponse sessionsResponse = adminClient.listSessions().get();
+        System.out.println("Active sessions: " + sessionsResponse.getSessionIds());
+
+        if (!sessionsResponse.getSessionIds().isEmpty()) {
+            long firstSessionId = sessionsResponse.getSessionIds().get(0);
+            System.out.println("Getting handles for session: " + firstSessionId);
+            // This is a conceptual call. To get handles, you would need a 'list_handles' request.
+            // We will assume a handle ID for the handle_info call.
+            long handleId = 123456789; // Replace with a real handle ID
+            // adminClient.handleInfo(firstSessionId, handleId).thenAccept(handleInfo -> {
+            //     System.out.println("Handle info: " + handleInfo.getInfo().toString(2));
+            // });
+        }
+
+        adminClient.disconnect();
+        System.out.println("\n--- Admin Client Example Finished ---\n");
     }
 }

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/JanusAdminClient.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/JanusAdminClient.java
@@ -1,0 +1,164 @@
+package io.github.kinsleykajiva.janus.admin;
+
+import io.github.kinsleykajiva.janus.admin.messages.HandleInfo;
+import io.github.kinsleykajiva.janus.admin.messages.HandleInfoResponse;
+import io.github.kinsleykajiva.janus.admin.messages.ListSessions;
+import io.github.kinsleykajiva.janus.admin.messages.ListSessionsResponse;
+import io.github.kinsleykajiva.janus.exception.JanusException;
+import io.github.kinsleykajiva.janus.internal.TransactionManager;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.util.concurrent.*;
+
+public class JanusAdminClient implements WebSocket.Listener {
+    private static final Logger logger = LoggerFactory.getLogger(JanusAdminClient.class);
+    private static final long DEFAULT_CONNECTION_TIMEOUT_MS = 10_000; // 10 seconds
+
+    private final JanusAdminConfiguration config;
+    private final HttpClient httpClient;
+    private WebSocket webSocket;
+    private final ExecutorService executor;
+    private final TransactionManager transactionManager;
+    private final StringBuilder messageBuffer = new StringBuilder();
+    private final JanusAdminMonitor adminMonitor;
+
+    public JanusAdminClient(JanusAdminConfiguration config) {
+        this.config = config;
+        this.transactionManager = new TransactionManager();
+        this.executor = Executors.newVirtualThreadPerTaskExecutor();
+        this.httpClient = HttpClient.newBuilder().executor(this.executor).build();
+        this.adminMonitor = new JanusAdminMonitor();
+
+        try {
+            logger.info("Starting admin connection attempt...");
+            connect().get();
+            logger.info("Admin connection established.");
+        } catch (InterruptedException e) {
+            logger.info("Program interrupted, shutting down.");
+            Thread.currentThread().interrupt(); // Restore interrupted status
+        } catch (Exception e) {
+            logger.error("Failed to connect to admin interface: {}", e.getMessage(), e);
+        }
+    }
+
+    public CompletableFuture<Void> connect() {
+        logger.info("Connecting to Janus Admin Gateway at {}", config.uri());
+        CompletableFuture<Void> connectionFuture = httpClient.newWebSocketBuilder()
+                .subprotocols("janus-admin-protocol")
+                .buildAsync(config.uri(), this)
+                .thenAccept(ws -> this.webSocket = ws);
+
+        return connectionFuture.orTimeout(DEFAULT_CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .exceptionally(throwable -> {
+                    logger.error("Failed to connect to Janus Admin Gateway at {}: {}", config.uri(), throwable.getMessage(), throwable);
+                    throw new JanusException("Admin connection failed", throwable);
+                });
+    }
+
+    public void disconnect() {
+        if (webSocket != null && !webSocket.isOutputClosed()) {
+            try {
+                webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "Client requested disconnect").get(5, TimeUnit.SECONDS);
+                logger.info("Disconnected from Janus Admin Gateway at {}", config.uri());
+            } catch (Exception e) {
+                logger.warn("Error during graceful WebSocket disconnect: {}", e.getMessage());
+            }
+        }
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void onOpen(WebSocket webSocket) {
+        logger.info("Successfully connected to Janus Admin Gateway at {}", config.uri());
+        webSocket.request(1);
+    }
+
+    @Override
+    public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+        messageBuffer.append(data);
+        if (last) {
+            String completeMessage = messageBuffer.toString();
+            executor.submit(() -> processMessage(completeMessage));
+            messageBuffer.setLength(0);
+        }
+        webSocket.request(1);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private void processMessage(String message) {
+        try {
+            JSONObject json = new JSONObject(message);
+            String transactionId = json.optString("transaction", null);
+            if (transactionId != null && !transactionId.isEmpty()) {
+                transactionManager.completeTransaction(transactionId, json);
+            } else {
+                adminMonitor.dispatchEvent(json);
+            }
+        } catch (JSONException e) {
+            logger.error("Error parsing JSON message: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected error processing message: {}", e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void onError(WebSocket webSocket, Throwable error) {
+        logger.error("WebSocket error at {}: {}", config.uri(), error.getMessage(), error);
+    }
+
+    @Override
+    public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+        logger.warn("WebSocket closed for {}: {} - {}", config.uri(), statusCode, reason);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    public void sendMessage(JSONObject message) {
+        if (webSocket == null || webSocket.isOutputClosed()) {
+            logger.error("Cannot send message: WebSocket is not connected to {}", config.uri());
+            throw new IllegalStateException("WebSocket is not connected.");
+        }
+        if (!message.has("admin_secret")) {
+            message.put("admin_secret", config.adminSecret());
+        }
+        String msgStr = message.toString();
+        logger.debug("Sending admin message: {}", msgStr);
+        webSocket.sendText(msgStr, true);
+    }
+
+    public TransactionManager getTransactionManager() {
+        return transactionManager;
+    }
+
+    public JanusAdminMonitor getAdminMonitor() {
+        return adminMonitor;
+    }
+
+    public CompletableFuture<ListSessionsResponse> listSessions() {
+        String transactionId = transactionManager.createTransaction();
+        var future = transactionManager.registerTransaction(transactionId);
+        ListSessions request = new ListSessions(transactionId);
+        sendMessage(request.toJson());
+        return future.thenApply(ListSessionsResponse::new);
+    }
+
+    public CompletableFuture<HandleInfoResponse> handleInfo(long sessionId, long handleId) {
+        String transactionId = transactionManager.createTransaction();
+        var future = transactionManager.registerTransaction(transactionId);
+        HandleInfo request = new HandleInfo(transactionId, sessionId, handleId);
+        sendMessage(request.toJson());
+        return future.thenApply(HandleInfoResponse::new);
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/JanusAdminConfiguration.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/JanusAdminConfiguration.java
@@ -1,0 +1,11 @@
+package io.github.kinsleykajiva.janus.admin;
+
+import java.net.URI;
+
+/**
+ * Configuration for the Janus Admin API client.
+ *
+ * @param uri          The URI of the Janus Admin WebSocket endpoint.
+ * @param adminSecret  The secret required to authenticate with the Admin API.
+ */
+public record JanusAdminConfiguration(URI uri, String adminSecret) {}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/JanusAdminEventListener.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/JanusAdminEventListener.java
@@ -1,0 +1,8 @@
+package io.github.kinsleykajiva.janus.admin;
+
+import org.json.JSONObject;
+
+@FunctionalInterface
+public interface JanusAdminEventListener {
+    void onEvent(JSONObject event);
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/JanusAdminMonitor.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/JanusAdminMonitor.java
@@ -1,0 +1,32 @@
+package io.github.kinsleykajiva.janus.admin;
+
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class JanusAdminMonitor {
+    private static final Logger logger = LoggerFactory.getLogger(JanusAdminMonitor.class);
+    private final List<JanusAdminEventListener> listeners = new CopyOnWriteArrayList<>();
+
+    public void addListener(JanusAdminEventListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeListener(JanusAdminEventListener listener) {
+        listeners.remove(listener);
+    }
+
+    public void dispatchEvent(JSONObject event) {
+        logger.debug("Dispatching admin event: {}", event.toString());
+        for (JanusAdminEventListener listener : listeners) {
+            try {
+                listener.onEvent(event);
+            } catch (Exception e) {
+                logger.error("Error in JanusAdminEventListener while processing event: {}", event.toString(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/DestroySession.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/DestroySession.java
@@ -1,0 +1,21 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONObject;
+
+public class DestroySession {
+    private final String transaction;
+    private final long sessionId;
+
+    public DestroySession(String transaction, long sessionId) {
+        this.transaction = transaction;
+        this.sessionId = sessionId;
+    }
+
+    public JSONObject toJson() {
+        JSONObject json = new JSONObject();
+        json.put("janus", "destroy_session");
+        json.put("transaction", transaction);
+        json.put("session_id", sessionId);
+        return json;
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/GetStatus.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/GetStatus.java
@@ -1,0 +1,18 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONObject;
+
+public class GetStatus {
+    private final String transaction;
+
+    public GetStatus(String transaction) {
+        this.transaction = transaction;
+    }
+
+    public JSONObject toJson() {
+        JSONObject json = new JSONObject();
+        json.put("janus", "get_status");
+        json.put("transaction", transaction);
+        return json;
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/HandleInfo.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/HandleInfo.java
@@ -1,0 +1,24 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONObject;
+
+public class HandleInfo {
+    private final String transaction;
+    private final long sessionId;
+    private final long handleId;
+
+    public HandleInfo(String transaction, long sessionId, long handleId) {
+        this.transaction = transaction;
+        this.sessionId = sessionId;
+        this.handleId = handleId;
+    }
+
+    public JSONObject toJson() {
+        JSONObject json = new JSONObject();
+        json.put("janus", "handle_info");
+        json.put("transaction", transaction);
+        json.put("session_id", sessionId);
+        json.put("handle_id", handleId);
+        return json;
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/HandleInfoResponse.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/HandleInfoResponse.java
@@ -1,0 +1,15 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONObject;
+
+public class HandleInfoResponse {
+    private final JSONObject info;
+
+    public HandleInfoResponse(JSONObject json) {
+        this.info = json.getJSONObject("info");
+    }
+
+    public JSONObject getInfo() {
+        return info;
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/Info.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/Info.java
@@ -1,0 +1,18 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONObject;
+
+public class Info {
+    private final String transaction;
+
+    public Info(String transaction) {
+        this.transaction = transaction;
+    }
+
+    public JSONObject toJson() {
+        JSONObject json = new JSONObject();
+        json.put("janus", "info");
+        json.put("transaction", transaction);
+        return json;
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/ListHandles.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/ListHandles.java
@@ -1,0 +1,21 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONObject;
+
+public class ListHandles {
+    private final String transaction;
+    private final long sessionId;
+
+    public ListHandles(String transaction, long sessionId) {
+        this.transaction = transaction;
+        this.sessionId = sessionId;
+    }
+
+    public JSONObject toJson() {
+        JSONObject json = new JSONObject();
+        json.put("janus", "list_handles");
+        json.put("transaction", transaction);
+        json.put("session_id", sessionId);
+        return json;
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/ListHandlesResponse.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/ListHandlesResponse.java
@@ -1,0 +1,23 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListHandlesResponse {
+    private final List<Long> handleIds;
+
+    public ListHandlesResponse(JSONObject json) {
+        JSONArray handlesArray = json.getJSONArray("handles");
+        this.handleIds = new ArrayList<>();
+        for (int i = 0; i < handlesArray.length(); i++) {
+            this.handleIds.add(handlesArray.getLong(i));
+        }
+    }
+
+    public List<Long> getHandleIds() {
+        return handleIds;
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/ListSessions.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/ListSessions.java
@@ -1,0 +1,18 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONObject;
+
+public class ListSessions {
+    private final String transaction;
+
+    public ListSessions(String transaction) {
+        this.transaction = transaction;
+    }
+
+    public JSONObject toJson() {
+        JSONObject json = new JSONObject();
+        json.put("janus", "list_sessions");
+        json.put("transaction", transaction);
+        return json;
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/ListSessionsResponse.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/ListSessionsResponse.java
@@ -1,0 +1,23 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListSessionsResponse {
+    private final List<Long> sessionIds;
+
+    public ListSessionsResponse(JSONObject json) {
+        JSONArray sessionsArray = json.getJSONArray("sessions");
+        this.sessionIds = new ArrayList<>();
+        for (int i = 0; i < sessionsArray.length(); i++) {
+            this.sessionIds.add(sessionsArray.getLong(i));
+        }
+    }
+
+    public List<Long> getSessionIds() {
+        return sessionIds;
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/MessagePlugin.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/MessagePlugin.java
@@ -1,0 +1,27 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONObject;
+
+public class MessagePlugin {
+    private final String transaction;
+    private final long sessionId;
+    private final long handleId;
+    private final JSONObject body;
+
+    public MessagePlugin(String transaction, long sessionId, long handleId, JSONObject body) {
+        this.transaction = transaction;
+        this.sessionId = sessionId;
+        this.handleId = handleId;
+        this.body = body;
+    }
+
+    public JSONObject toJson() {
+        JSONObject json = new JSONObject();
+        json.put("janus", "message_plugin");
+        json.put("transaction", transaction);
+        json.put("session_id", sessionId);
+        json.put("handle_id", handleId);
+        json.put("body", body);
+        return json;
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/Ping.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/Ping.java
@@ -1,0 +1,18 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONObject;
+
+public class Ping {
+    private final String transaction;
+
+    public Ping(String transaction) {
+        this.transaction = transaction;
+    }
+
+    public JSONObject toJson() {
+        JSONObject json = new JSONObject();
+        json.put("janus", "ping");
+        json.put("transaction", transaction);
+        return json;
+    }
+}

--- a/src/main/java/io/github/kinsleykajiva/janus/admin/messages/SetLogLevel.java
+++ b/src/main/java/io/github/kinsleykajiva/janus/admin/messages/SetLogLevel.java
@@ -1,0 +1,21 @@
+package io.github.kinsleykajiva.janus.admin.messages;
+
+import org.json.JSONObject;
+
+public class SetLogLevel {
+    private final String transaction;
+    private final int level;
+
+    public SetLogLevel(String transaction, int level) {
+        this.transaction = transaction;
+        this.level = level;
+    }
+
+    public JSONObject toJson() {
+        JSONObject json = new JSONObject();
+        json.put("janus", "set_log_level");
+        json.put("transaction", transaction);
+        json.put("level", level);
+        return json;
+    }
+}


### PR DESCRIPTION
This commit introduces a new feature: a Janus Admin API client.

- Adds a `JanusAdminClient` for connecting to the Janus Admin WebSocket.
- Implements request and response models for Admin API messages, starting with `list_sessions` and `handle_info`.
- Provides a `JanusAdminMonitor` for handling asynchronous events from the admin WebSocket.
- Includes an example in `Main.java` to demonstrate the usage of the new admin client.